### PR TITLE
update pypi publish workflow

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -1,10 +1,12 @@
 name: Call PyPI publish workflow
-on: push
+on:
+  release:
+    types: [published]
 jobs:
   call-pypi-publish:
     uses: ghga-de/gh-action-pypi/.github/workflows/pypi_publish.yml@v2.0.0
     with:
       package_version: 2.0.0-alpha.5
-      test_pypi: "true"
+      test_pypi: "false"
       python_latest: true
     secrets: inherit

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -1,74 +1,12 @@
-name: PyPI Publish
-
+name: Call PyPI publish workflow
 on:
   release:
     types: [published]
-
 jobs:
-  pypi-publish:
-    name: Publish tagged release on PyPI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-
-      - name: Ensure package version and tag are equal
-        run: |
-
-          PKG_VER="$(grep -oP '^version = "\K[^"]+' pyproject.toml)"
-          TAG_VER="${GITHUB_REF##*/}"
-
-          echo "Package version is $PKG_VER" >&2
-          echo "Tag version is $TAG_VER" >&2
-          if [ "$PKG_VER" != "$TAG_VER" ]; then
-            echo "Package version and tag name mismatch." >&2
-            exit 1
-          fi
-
-      - name: Install pypa/build
-        run: >-
-          python -m
-          pip install
-          build
-          --user
-
-      - name: Build a binary wheel and a source tarball
-        run: >-
-          python -m
-          build
-          --sdist
-          --wheel
-          --outdir dist/
-          .
-
-      - name: Install the newly built package with all extras
-        run: |
-          TAR_PATH="$( realpath ./dist/*.tar.gz)"
-          python -m \
-            pip install \
-            "${TAR_PATH}[all]"
-
-      - name: Install testing requirements
-        run: >-
-          python -m
-          pip install
-          --no-deps -r ./lock/requirements-dev.txt
-
-      - name: Run pytest on freshly installed package
-        run: |
-          pytest .
-
-      - name: Publish distribution package to PyPI (test)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-
-      - name: Publish distribution package to PyPI (production)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  call-pypi-publish:
+    uses: ghga-de/gh-action-pypi/.github/workflows/pypi_publish.yml@v2.0.0
+    with:
+      package_version: 3.0.0
+      test_pypi: "false"
+      python_latest: true
+    secrets: inherit

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -1,12 +1,10 @@
 name: Call PyPI publish workflow
-on:
-  release:
-    types: [published]
+on: push
 jobs:
   call-pypi-publish:
     uses: ghga-de/gh-action-pypi/.github/workflows/pypi_publish.yml@v2.0.0
     with:
       package_version: 2.0.0-alpha.5
-      test_pypi: "false"
+      test_pypi: "true"
       python_latest: true
     secrets: inherit

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -6,7 +6,7 @@ jobs:
   call-pypi-publish:
     uses: ghga-de/gh-action-pypi/.github/workflows/pypi_publish.yml@v2.0.0
     with:
-      package_version: 3.0.0
+      package_version: 2.0.0-alpha.5
       test_pypi: "false"
       python_latest: true
     secrets: inherit


### PR DESCRIPTION
The workflow is updated with [ghga-de/gh-action-pypi](https://github.com/ghga-de/gh-action-pypi) (An example use of it is available on [ghga-transpiler](https://github.com/ghga-de/ghga-transpiler/blob/main/.github/workflows/pypi_publish.yaml)).