### PR TITLE
Extend supported versions

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "schemapack"
-version = "3.1.0"
+version = "4.0.0"
 description = "Make your JSON Schemas sociable and create linked data model."
 dependencies = [
     "pydantic >=2, <3",

--- a/examples/datapack/invalid/all_mandatory/MissingMandatoryOriginError.datapack.yaml
+++ b/examples/datapack/invalid/all_mandatory/MissingMandatoryOriginError.datapack.yaml
@@ -1,6 +1,6 @@
 # One target resource is not referenced by any origin resource through a relation that
 # is mandatory at the origin end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/all_mandatory/MissingMandatoryTargetError.datapack.yaml
+++ b/examples/datapack/invalid/all_mandatory/MissingMandatoryTargetError.datapack.yaml
@@ -1,6 +1,6 @@
 # An origin resource references no target resources through a relation that is defined
 # mandatory at the target end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/all_mandatory_non_multiple_target/MissingMandatoryOriginError.datapack.yaml
+++ b/examples/datapack/invalid/all_mandatory_non_multiple_target/MissingMandatoryOriginError.datapack.yaml
@@ -1,6 +1,6 @@
 # One target resource is not referenced by any origin resource through a relation that
 # is mandatory at the origin end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/all_mandatory_non_multiple_target/MissingMandatoryTargetError.datapack.yaml
+++ b/examples/datapack/invalid/all_mandatory_non_multiple_target/MissingMandatoryTargetError.datapack.yaml
@@ -1,6 +1,6 @@
 # An origin resource references no target resources through a relation that is defined
 # mandatory at the target end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/complex_cardinality/CardinalityOverlapError.one_to_many.datapack.yaml
+++ b/examples/datapack/invalid/complex_cardinality/CardinalityOverlapError.one_to_many.datapack.yaml
@@ -1,5 +1,5 @@
 # Partial overlap in a relation property with one_to_many cardinality:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/complex_cardinality/CardinalityOverlapError.one_to_one.datapack.yaml
+++ b/examples/datapack/invalid/complex_cardinality/CardinalityOverlapError.one_to_one.datapack.yaml
@@ -1,5 +1,5 @@
 # Partial overlap in a relation property with one_to_one cardinality:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/complex_cardinality/CardinalityPluralityError.many_to_many.datapack.yaml
+++ b/examples/datapack/invalid/complex_cardinality/CardinalityPluralityError.many_to_many.datapack.yaml
@@ -1,6 +1,6 @@
 # Relation property that is expected to be of many_to_many cardinality is not specified
 # as list:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/complex_cardinality/CardinalityPluralityError.many_to_one.datapack.yaml
+++ b/examples/datapack/invalid/complex_cardinality/CardinalityPluralityError.many_to_one.datapack.yaml
@@ -1,6 +1,6 @@
 # Relation property that is expected to be of many_to_one cardinality is specified as
 # list:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/complex_cardinality/CardinalityPluralityError.one_to_many.datapack.yaml
+++ b/examples/datapack/invalid/complex_cardinality/CardinalityPluralityError.one_to_many.datapack.yaml
@@ -1,6 +1,6 @@
 # Relation property that is expected to be of many_to_one cardinality is not specified
 # as list:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/complex_cardinality/CardinalityPluralityError.one_to_one.datapack.yaml
+++ b/examples/datapack/invalid/complex_cardinality/CardinalityPluralityError.one_to_one.datapack.yaml
@@ -1,6 +1,6 @@
 # Relation property that is expected to be of one_to_one cardinality is specified as
 # list:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/invalid/self_relation/UnexpectedRootDefinitionError.datapack.yaml
+++ b/examples/datapack/invalid/self_relation/UnexpectedRootDefinitionError.datapack.yaml
@@ -1,5 +1,5 @@
 # The corresponding schemapack expects no root but a root resource is defined:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/invalid/self_relation_rooted/DataPackSpecError.UnkownRootResourceError.datapack.yaml
+++ b/examples/datapack/invalid/self_relation_rooted/DataPackSpecError.UnkownRootResourceError.datapack.yaml
@@ -1,5 +1,5 @@
 # The corresponding schemapack expects a root but no root resource is defined:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/invalid/self_relation_rooted/ExpectedRootDefinitionError.datapack.yaml
+++ b/examples/datapack/invalid/self_relation_rooted/ExpectedRootDefinitionError.datapack.yaml
@@ -1,5 +1,5 @@
 # The corresponding schemapack expects a root but no root resource is defined:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/invalid/simple_relations/ContentValidationError.missing_property.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/ContentValidationError.missing_property.datapack.yaml
@@ -1,5 +1,5 @@
 # Misses content property defined in the content schema:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/invalid/simple_relations/ContentValidationError.unkown_property.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/ContentValidationError.unkown_property.datapack.yaml
@@ -1,5 +1,5 @@
 # Contains a content property that does not exist according to the content schema:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/invalid/simple_relations/ContentValidationError.wrong_type.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/ContentValidationError.wrong_type.datapack.yaml
@@ -1,5 +1,5 @@
 # A content property has the wrong type according to the content schema:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.DuplicateTargetIdError.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.DuplicateTargetIdError.datapack.yaml
@@ -1,5 +1,5 @@
 # A target ID in a relation is used more than once:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.TargetClassNotFoundError.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.TargetClassNotFoundError.datapack.yaml
@@ -1,5 +1,5 @@
 # Every target class defined in the relations must be present in the datapack
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   Dataset:
     example_dataset:

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.TargetIdNotFoundError.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.TargetIdNotFoundError.datapack.yaml
@@ -1,5 +1,5 @@
 # One relation points to a non-existing resource:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File: {}
   Dataset:

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.UnknownRootClassError.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.UnknownRootClassError.datapack.yaml
@@ -1,5 +1,5 @@
 # Using a root class that is not in datapack classes
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.UnknownRootResourceError.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.UnknownRootResourceError.datapack.yaml
@@ -1,5 +1,5 @@
 # Using a root resource that is not in datapack SomCelass resources
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.empty_resource_id.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.empty_resource_id.datapack.yaml
@@ -1,5 +1,5 @@
 # using an empty string as resource ID:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.extra_field.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.extra_field.datapack.yaml
@@ -1,5 +1,5 @@
 # Additional field that is not part of the DataPack specification:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File: {}
   Dataset:

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.missing_content.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.missing_content.datapack.yaml
@@ -1,5 +1,5 @@
 # Contains no content definition for one resource:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File: {}
   Dataset:

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.missing_resources.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.missing_resources.datapack.yaml
@@ -1,2 +1,2 @@
 # Missing resources field:
-datapack: 0.3.0
+datapack: 3.0.0

--- a/examples/datapack/invalid/simple_relations/DataPackSpecError.non_string_id.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/DataPackSpecError.non_string_id.datapack.yaml
@@ -1,5 +1,5 @@
 # Using a non-string value as resource identifier:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     1234: # <-

--- a/examples/datapack/invalid/simple_relations/MissingClassSlotError.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/MissingClassSlotError.datapack.yaml
@@ -1,6 +1,6 @@
 # Every class defined in the schemapack must be present in the datapack even if no
 # resources for that class are available:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   # missing slot for File
   Dataset:

--- a/examples/datapack/invalid/simple_relations/MissingRelationPropertyError.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/MissingRelationPropertyError.datapack.yaml
@@ -1,5 +1,5 @@
 # Misses relations property defined in the schemapack:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File: {}
   Dataset:

--- a/examples/datapack/invalid/simple_relations/ParsingError.duplicate_resource_id.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/ParsingError.duplicate_resource_id.datapack.yaml
@@ -1,5 +1,5 @@
 # Using a duplicate resource id:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/invalid/simple_relations/UnknownClassSlotError.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/UnknownClassSlotError.datapack.yaml
@@ -1,5 +1,5 @@
 # Contains a slot for a class that does not exist in the schemapack:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File: {}
   Dataset:

--- a/examples/datapack/invalid/simple_relations/UnknownRelationPropertyError.datapack.yaml
+++ b/examples/datapack/invalid/simple_relations/UnknownRelationPropertyError.datapack.yaml
@@ -1,5 +1,5 @@
 # Contains a relation property that does not exist according to the schemapack:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/valid/all_mandatory/all_targets_referenced.datapack.yaml
+++ b/examples/datapack/valid/all_mandatory/all_targets_referenced.datapack.yaml
@@ -1,5 +1,5 @@
 # Every target is referenced but not all by the same origin resource:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/all_mandatory_non_multiple_target/all_targets_referenced.datapack.yaml
+++ b/examples/datapack/valid/all_mandatory_non_multiple_target/all_targets_referenced.datapack.yaml
@@ -1,5 +1,5 @@
 # Every target is referenced but not all by the same origin resource:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/complex_cardinality/all_cardinalities.datapack.yaml
+++ b/examples/datapack/valid/complex_cardinality/all_cardinalities.datapack.yaml
@@ -1,5 +1,5 @@
 # Contains all cardinality types:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/complex_cardinality_rooted/rooted_all_cardinalities.datapack.yaml
+++ b/examples/datapack/valid/complex_cardinality_rooted/rooted_all_cardinalities.datapack.yaml
@@ -1,6 +1,6 @@
 # Contains all cardinality types:
 # (Same as ./all_cardinalities.datapack.yaml, but rooted to a1.)
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/empty_resources/emptyresources.datapack.yaml
+++ b/examples/datapack/valid/empty_resources/emptyresources.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     file_a:

--- a/examples/datapack/valid/optional_non_multiple_target/empty_targets.datapack.yaml
+++ b/examples/datapack/valid/optional_non_multiple_target/empty_targets.datapack.yaml
@@ -1,6 +1,6 @@
 # An origin resource references no target resources for a relation that is defined
 # optional at the target end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/optional_non_multiple_target/single_target.datapack.yaml
+++ b/examples/datapack/valid/optional_non_multiple_target/single_target.datapack.yaml
@@ -1,6 +1,6 @@
 # An origin resource references a single target resources even though the relation is
 # defined optional at the target end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/optional_origin/not_all_targets_references.datapack.yaml
+++ b/examples/datapack/valid/optional_origin/not_all_targets_references.datapack.yaml
@@ -1,6 +1,6 @@
 # Not all target resources are referenced through a relation that is optional at the
 # origin end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/optional_origin_non_multiple_target/not_all_targets_references.datapack.yaml
+++ b/examples/datapack/valid/optional_origin_non_multiple_target/not_all_targets_references.datapack.yaml
@@ -1,6 +1,6 @@
 # Not all target resources are referenced through a relation that is optional at the
 # origin end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/optional_target/empty_targets.datapack.yaml
+++ b/examples/datapack/valid/optional_target/empty_targets.datapack.yaml
@@ -1,6 +1,6 @@
 # An origin resource references no target resources for a relation that is defined
 # optional at the target end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/optional_target/multiple_targets.datapack.yaml
+++ b/examples/datapack/valid/optional_target/multiple_targets.datapack.yaml
@@ -1,6 +1,6 @@
 # An origin resource references multiple target resources even though the relation is
 # defined optional at the target end:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/self_relation/circular_relations.datapack.yaml
+++ b/examples/datapack/valid/self_relation/circular_relations.datapack.yaml
@@ -1,6 +1,6 @@
 # This datapack has a circular relation between two resources:
 # (This is valid, but no denormalization can be performed.)
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/valid/self_relation/circular_self_relations.datapack.yaml
+++ b/examples/datapack/valid/self_relation/circular_self_relations.datapack.yaml
@@ -1,6 +1,6 @@
 # This datapack contains a resource that is in relation to itself:
 # (This is valid, but no denormalization can be performed.)
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/valid/self_relation/commented_content.datapack.yaml
+++ b/examples/datapack/valid/self_relation/commented_content.datapack.yaml
@@ -1,6 +1,6 @@
 # Using comments in content should not cause any problems
 # but did in the past.
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/valid/self_relation/multiple_relation_groups.datapack.yaml
+++ b/examples/datapack/valid/self_relation/multiple_relation_groups.datapack.yaml
@@ -2,7 +2,7 @@
 # within the group but not across groups. Rooting to a specific resource would result
 # in the deletion of unrelated resources.
 # (Same as ./nested_relations.datapack.yaml, but with a additional unrelated resources.)
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     # one group of resources:

--- a/examples/datapack/valid/self_relation/nested_relations.datapack.yaml
+++ b/examples/datapack/valid/self_relation/nested_relations.datapack.yaml
@@ -1,5 +1,5 @@
 # Nested relations between resources of the same type:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/valid/self_relation_rooted/rooted_circular_relations.datapack.yaml
+++ b/examples/datapack/valid/self_relation_rooted/rooted_circular_relations.datapack.yaml
@@ -1,6 +1,6 @@
 # This datapack has a circular relation between two resources:
 # (This is valid, but no denormalization can be performed.)
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/valid/self_relation_rooted/rooted_circular_self_relations.datapack.yaml
+++ b/examples/datapack/valid/self_relation_rooted/rooted_circular_self_relations.datapack.yaml
@@ -1,6 +1,6 @@
 # This datapack contains a resource that is in relation to itself:
 # (This is valid, but no denormalization can be performed.)
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/valid/self_relation_rooted/rooted_nested_relations.datapack.yaml
+++ b/examples/datapack/valid/self_relation_rooted/rooted_nested_relations.datapack.yaml
@@ -1,6 +1,6 @@
 # Nested relations between resources of the same type:
 # (Same as ./multiple_relation_groups.datapack.yaml, but rooted to example_file_a)
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   SomeClass:
     a:

--- a/examples/datapack/valid/simple_relations/no_resources.datapack.yaml
+++ b/examples/datapack/valid/simple_relations/no_resources.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File: {}
   Dataset: {}

--- a/examples/datapack/valid/simple_relations/optional_property_missing.datapack.yaml
+++ b/examples/datapack/valid/simple_relations/optional_property_missing.datapack.yaml
@@ -1,5 +1,5 @@
 # Missing optional property
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/valid/simple_relations/simple_resources.datapack.yaml
+++ b/examples/datapack/valid/simple_relations/simple_resources.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/valid/simple_relations_rooted/rooted_simple_resources.datapack.yaml
+++ b/examples/datapack/valid/simple_relations_rooted/rooted_simple_resources.datapack.yaml
@@ -1,5 +1,5 @@
 # Same as ./non_rooted.datapack.yaml, but rooted to example_dataset:
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   File:
     example_file_a:

--- a/examples/datapack/valid/simple_relations_rooted_nested/simple_nested_relations.datapack.yaml
+++ b/examples/datapack/valid/simple_relations_rooted_nested/simple_nested_relations.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   A:
     a1:

--- a/examples/datapack/valid/team/team.datapack.yaml
+++ b/examples/datapack/valid/team/team.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
     Person:
         Alice:

--- a/examples/datapack/valid/team_rooted/team_rooted_self_relation.datapack.yaml
+++ b/examples/datapack/valid/team_rooted/team_rooted_self_relation.datapack.yaml
@@ -1,4 +1,4 @@
-datapack: 0.3.0
+datapack: 3.0.0
 resources:
   Person:
     Alice:

--- a/examples/schemapack/invalid/ContentSchemaNotFoundError.schemapack.yaml
+++ b/examples/schemapack/invalid/ContentSchemaNotFoundError.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   Dataset:
     id:

--- a/examples/schemapack/invalid/IdContentPropertyCollisionError.schemapack.yaml
+++ b/examples/schemapack/invalid/IdContentPropertyCollisionError.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A collision between the ID property and the content properties
 classes:
   File:

--- a/examples/schemapack/invalid/IdRelationsPropertyCollisionError.schemapack.yaml
+++ b/examples/schemapack/invalid/IdRelationsPropertyCollisionError.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A collision between the ID property and relations properties
 classes:
   File:

--- a/examples/schemapack/invalid/InvalidContentSchemaError.invalid_json.schemapack.yaml
+++ b/examples/schemapack/invalid/InvalidContentSchemaError.invalid_json.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   Dataset:
     id:

--- a/examples/schemapack/invalid/InvalidContentSchemaError.invalid_json_schema.schemapack.yaml
+++ b/examples/schemapack/invalid/InvalidContentSchemaError.invalid_json_schema.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description:
 classes:
   Dataset:

--- a/examples/schemapack/invalid/InvalidContentSchemaError.non_object.schemapack.yaml
+++ b/examples/schemapack/invalid/InvalidContentSchemaError.non_object.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: The content schema does not describe a JSON object.
 classes:
   Dataset:

--- a/examples/schemapack/invalid/RelationClassNotFoundError.schemapack.yaml
+++ b/examples/schemapack/invalid/RelationClassNotFoundError.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   Dataset:
     id:

--- a/examples/schemapack/invalid/RelationsContentPropertyCollisionError.schemapack.yaml
+++ b/examples/schemapack/invalid/RelationsContentPropertyCollisionError.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A collision between relations and content properties
 classes:
   File:

--- a/examples/schemapack/invalid/RootClassNotFoundError.schemapack.yaml
+++ b/examples/schemapack/invalid/RootClassNotFoundError.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: Refering to a non-existing class as root
 classes:
   SomeClass:

--- a/examples/schemapack/invalid/extra_forbidden.at_class.schemapack.yaml
+++ b/examples/schemapack/invalid/extra_forbidden.at_class.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: attributes that are not part of the schemapack spec are not allowed
 classes:
   Dataset:

--- a/examples/schemapack/invalid/extra_forbidden.at_relation.schemapack.yaml
+++ b/examples/schemapack/invalid/extra_forbidden.at_relation.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: attributes that are not part of the schemapack spec are not allowed
 classes:
   File:

--- a/examples/schemapack/invalid/extra_forbidden.at_top.schemapack.yaml
+++ b/examples/schemapack/invalid/extra_forbidden.at_top.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: attributes that are not part of the schemapack spec are not allowed
 classes:
   Dataset:

--- a/examples/schemapack/invalid/missing.classes.schemapack.yaml
+++ b/examples/schemapack/invalid/missing.classes.schemapack.yaml
@@ -1,2 +1,2 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: no classes attribute specified

--- a/examples/schemapack/invalid/missing.content.schemapack.yaml
+++ b/examples/schemapack/invalid/missing.content.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   Dataset:
     id:

--- a/examples/schemapack/invalid/missing.id.schemapack.yaml
+++ b/examples/schemapack/invalid/missing.id.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   Dataset:
     content: ../../content_schemas/Dataset.schema.json

--- a/examples/schemapack/invalid/missing.id_propertyName.schemapack.yaml
+++ b/examples/schemapack/invalid/missing.id_propertyName.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   Dataset:
     id: {} # <-

--- a/examples/schemapack/invalid/missing.mandatory.schemapack.yaml
+++ b/examples/schemapack/invalid/missing.mandatory.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   File:
     id:

--- a/examples/schemapack/invalid/missing.multiple.schemapack.yaml
+++ b/examples/schemapack/invalid/missing.multiple.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   File:
     id:

--- a/examples/schemapack/invalid/too_short.empty_classes.schemapack.yaml
+++ b/examples/schemapack/invalid/too_short.empty_classes.schemapack.yaml
@@ -1,2 +1,2 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes: {} # there must be at least one class

--- a/examples/schemapack/valid/all_mandatory.schemapack.yaml
+++ b/examples/schemapack/valid/all_mandatory.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a schemapack with a many-to-many relation that is mandatory at both ends
 classes:
   A:

--- a/examples/schemapack/valid/all_mandatory_non_multiple_target.schemapack.yaml
+++ b/examples/schemapack/valid/all_mandatory_non_multiple_target.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a schemapack with a many-to-one relation that is mandatory at both ends
 classes:
   A:

--- a/examples/schemapack/valid/complex_cardinality.schemapack.yaml
+++ b/examples/schemapack/valid/complex_cardinality.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a schemapack illustrating all possible cardinalities
 classes:
   A:

--- a/examples/schemapack/valid/complex_cardinality_rooted.schemapack.yaml
+++ b/examples/schemapack/valid/complex_cardinality_rooted.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a schemapack illustrating all possible cardinalities
 classes:
   A:

--- a/examples/schemapack/valid/comprehensive_cardinalities_and_types.schemapack.yaml
+++ b/examples/schemapack/valid/comprehensive_cardinalities_and_types.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a schemapack that utilizes most cardinalities, modalities and json schema types
 classes:
   Customer:
@@ -124,7 +124,6 @@ classes:
         multiple:
           origin: true
           target: true
-
 
   ProductCategory:
     id:

--- a/examples/schemapack/valid/empty_resources.schemapack.yaml
+++ b/examples/schemapack/valid/empty_resources.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   File:
     id:

--- a/examples/schemapack/valid/no_relations.schemapack.yaml
+++ b/examples/schemapack/valid/no_relations.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: there is little value in a schemapack without relations but it is syntactically valid
 classes:
   File:

--- a/examples/schemapack/valid/optional_non_multiple_target.schemapack.yaml
+++ b/examples/schemapack/valid/optional_non_multiple_target.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a schemapack with a many-to-one relation that is optional at the target end
 classes:
   A:

--- a/examples/schemapack/valid/optional_origin.schemapack.yaml
+++ b/examples/schemapack/valid/optional_origin.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a schemapack with a many-to-many relation that is optional at the origin end
 classes:
   A:

--- a/examples/schemapack/valid/optional_origin_non_multiple_target.schemapack.yaml
+++ b/examples/schemapack/valid/optional_origin_non_multiple_target.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a schemapack with a many-to-one relation that is optional at the origin end
 classes:
   A:

--- a/examples/schemapack/valid/optional_target.schemapack.yaml
+++ b/examples/schemapack/valid/optional_target.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a schemapack with a many-to-many relation that is optional at the target end
 classes:
   A:

--- a/examples/schemapack/valid/self_relation.schemapack.yaml
+++ b/examples/schemapack/valid/self_relation.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A class referencing itself in a relation
 classes:
   SomeClass:

--- a/examples/schemapack/valid/self_relation_rooted.schemapack.yaml
+++ b/examples/schemapack/valid/self_relation_rooted.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A class referencing itself in a relation
 classes:
   SomeClass:

--- a/examples/schemapack/valid/simple_relations.schemapack.yaml
+++ b/examples/schemapack/valid/simple_relations.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A simple schemapack # with no root class but with descriptions.
 classes:
   File:

--- a/examples/schemapack/valid/simple_relations_condensed.schemapack.yaml
+++ b/examples/schemapack/valid/simple_relations_condensed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A simple schemapack
 classes:
   Dataset:

--- a/examples/schemapack/valid/simple_relations_rooted.schemapack.yaml
+++ b/examples/schemapack/valid/simple_relations_rooted.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A simple schemapack
 classes:
   File:

--- a/examples/schemapack/valid/simple_relations_rooted_condensed.schemapack.yaml
+++ b/examples/schemapack/valid/simple_relations_rooted_condensed.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A simple schemapack
 classes:
   Dataset:

--- a/examples/schemapack/valid/simple_relations_rooted_nested.schemapack.yaml
+++ b/examples/schemapack/valid/simple_relations_rooted_nested.schemapack.yaml
@@ -1,5 +1,5 @@
 # a simple schemapack:
-schemapack: 0.3.0
+schemapack: 3.0.0
 classes:
   A:
     id:

--- a/examples/schemapack/valid/simple_relations_with_description.schemapack.yaml
+++ b/examples/schemapack/valid/simple_relations_with_description.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A simple schemapack
 classes:
   File:

--- a/examples/schemapack/valid/team.schemapack.yaml
+++ b/examples/schemapack/valid/team.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A schema used to describe relationships between team members.
 classes:
   Person:

--- a/examples/schemapack/valid/team_rooted.schemapack.yaml
+++ b/examples/schemapack/valid/team_rooted.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: A schema used to describe relationships between team members.
 classes:
   Person:

--- a/examples/schemapack/valid/unrelated_classes.schemapack.yaml
+++ b/examples/schemapack/valid/unrelated_classes.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: Two unrelated classes
 classes:
   SomeClass:

--- a/examples/schemapack/valid/unrelated_classes_rooted.schemapack.yaml
+++ b/examples/schemapack/valid/unrelated_classes_rooted.schemapack.yaml
@@ -1,6 +1,7 @@
-schemapack: 0.3.0
-description: Two unrelated classes # but rooted to one class so that only that class is
-            # kept.
+schemapack: 3.0.0
+description:
+  Two unrelated classes # but rooted to one class so that only that class is
+  # kept.
 classes:
   SomeClass:
     id:

--- a/examples/schemapack/valid/with_relation_lookup.schemapack.yaml
+++ b/examples/schemapack/valid/with_relation_lookup.schemapack.yaml
@@ -1,4 +1,4 @@
-schemapack: 0.3.0
+schemapack: 3.0.0
 description: a simple schema with an embedded relation
 classes:
   File:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "schemapack"
-version = "3.1.0"
+version = "4.0.0"
 description = "Make your JSON Schemas sociable and create linked data model."
 dependencies = [
     "pydantic >=2, <3",

--- a/src/schemapack/_internals/spec/datapack.py
+++ b/src/schemapack/_internals/spec/datapack.py
@@ -35,7 +35,7 @@ from schemapack._internals.spec.custom_types import (
     ResourceId,
 )
 
-SupportedDataPackVersions =  Literal["3.0.0", "3.1.0", "4.0.0"]
+SupportedDataPackVersions = Literal["3.0.0", "3.1.0", "4.0.0"]
 SUPPORTED_DATA_PACK_VERSIONS = typing.get_args(SupportedDataPackVersions)
 
 

--- a/src/schemapack/_internals/spec/datapack.py
+++ b/src/schemapack/_internals/spec/datapack.py
@@ -35,7 +35,7 @@ from schemapack._internals.spec.custom_types import (
     ResourceId,
 )
 
-SupportedDataPackVersions =  Literal["3.0.0", "3.1.0", "3.1.1"]
+SupportedDataPackVersions =  Literal["3.0.0", "3.1.0", "4.0.0"]
 SUPPORTED_DATA_PACK_VERSIONS = typing.get_args(SupportedDataPackVersions)
 
 

--- a/src/schemapack/_internals/spec/datapack.py
+++ b/src/schemapack/_internals/spec/datapack.py
@@ -35,7 +35,7 @@ from schemapack._internals.spec.custom_types import (
     ResourceId,
 )
 
-SupportedDataPackVersions = Literal["0.3.0"]
+SupportedDataPackVersions =  Literal["3.0.0", "3.1.0", "3.1.1"]
 SUPPORTED_DATA_PACK_VERSIONS = typing.get_args(SupportedDataPackVersions)
 
 

--- a/src/schemapack/_internals/spec/schemapack.py
+++ b/src/schemapack/_internals/spec/schemapack.py
@@ -43,7 +43,7 @@ from schemapack.spec.custom_types import (
 )
 from schemapack.utils import read_json_or_yaml_mapping
 
-SupportedSchemaPackVersions = Literal["0.3.0"]
+SupportedSchemaPackVersions = Literal["3.0.0", "3.1.0", "3.1.1"]
 SUPPORTED_SCHEMA_PACK_VERSIONS = typing.get_args(SupportedSchemaPackVersions)
 
 

--- a/src/schemapack/_internals/spec/schemapack.py
+++ b/src/schemapack/_internals/spec/schemapack.py
@@ -43,7 +43,7 @@ from schemapack.spec.custom_types import (
 )
 from schemapack.utils import read_json_or_yaml_mapping
 
-SupportedSchemaPackVersions = Literal["3.0.0", "3.1.0", "3.1.1"]
+SupportedSchemaPackVersions = Literal["3.0.0", "3.1.0", "4.0.0"]
 SUPPORTED_SCHEMA_PACK_VERSIONS = typing.get_args(SupportedSchemaPackVersions)
 
 


### PR DESCRIPTION
The list of supported versions has been updated. This constitutes a major version bump because 0.3.0 is no longer supported.

Since the list of supported versions is still small, the `Literal` approach remains unchanged. In the future, if the list becomes longer, we can switch to an approach that defines a minimum and maximum supported version and evaluates whether the given version falls within the interval.